### PR TITLE
dplyr 1.0.8: avoid using matrices in `filter()`

### DIFF
--- a/R/pool_D4.R
+++ b/R/pool_D4.R
@@ -49,7 +49,7 @@ pool_D4 <- function(data,
 {
   m <- nimp
   data <-
-    filter(data, data[impvar] <= nimp)
+    filter(data, data[[impvar]] <= nimp)
   
   if(model_type=="binomial") family="binomial"
   if(model_type=="linear") family="gaussian"

--- a/R/psfmi_lm_bw.R
+++ b/R/psfmi_lm_bw.R
@@ -112,7 +112,7 @@ psfmi_lm_bw <- function(data, nimp, impvar, Outcome, P, p.crit, method, keep.P)
         }
         if(method=="D4"){
           data <-
-            filter(data, data[impvar] <= nimp)
+            filter(data, data[[impvar]] <= nimp)
           imp_list <-
             data %>% group_split(data[, impvar], .keep = FALSE) %>%
             mitools::imputationList(imp_list)

--- a/R/psfmi_lm_fw.R
+++ b/R/psfmi_lm_fw.R
@@ -124,7 +124,7 @@ psfmi_lm_fw <- function(data, nimp, impvar, Outcome, P, p.crit, method, keep.P)
         }
         if(method=="D4"){
           data <-
-            filter(data, data[impvar] <= nimp)
+            filter(data, data[[impvar]] <= nimp)
           imp_list <-
             data %>% group_split(data[, impvar], .keep = FALSE) %>%
             mitools::imputationList(imp_list)

--- a/R/psfmi_lr_bw.R
+++ b/R/psfmi_lr_bw.R
@@ -123,7 +123,7 @@ psfmi_lr_bw <- function(data, nimp, impvar, Outcome, P, p.crit, method, keep.P)
         }
         if(method=="D4"){
           data <-
-            filter(data, data[impvar] <= nimp)
+            filter(data, data[[impvar]] <= nimp)
           imp_list <-
             data %>% group_split(data[, impvar], .keep = FALSE) %>%
             mitools::imputationList(imp_list)
@@ -162,7 +162,7 @@ psfmi_lr_bw <- function(data, nimp, impvar, Outcome, P, p.crit, method, keep.P)
         }
         if(method=="D3"){
           data <-
-            filter(data, data[impvar] <= nimp)
+            filter(data, data[[impvar]] <= nimp)
           imp_list <-
             data %>% group_split(data[, impvar], .keep = FALSE) %>%
             mitools::imputationList(imp_list)

--- a/R/psfmi_lr_fw.R
+++ b/R/psfmi_lr_fw.R
@@ -129,7 +129,7 @@ psfmi_lr_fw <- function(data, nimp, impvar, Outcome, P, p.crit, method, keep.P)
         }
         if(method=="D4"){
           data <-
-            filter(data, data[impvar] <= nimp)
+            filter(data, data[[impvar]] <= nimp)
           imp_list <-
             data %>% group_split(data[, impvar], .keep = FALSE) %>%
             mitools::imputationList(imp_list)


### PR DESCRIPTION
We're about to release `dplyr` 1.0.8 which is stricter about what is allowed in `filter()`. As part of running our rev dep checks we've identified that this package potentially fails with: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘psfmi-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: pool_D4
  > ### Title: Pools the Likelihood Ratio tests across Multiply Imputed
  > ###   datasets ( method D4)
  > ### Aliases: pool_D4
  > 
  > ### ** Examples
  > 
  > 
  > fm0 <- Chronic ~ BMI + factor(Carrying) + 
  +   Satisfaction + SocialSupport + Smoking
  > fm1 <- Chronic ~ BMI + factor(Carrying) + 
  +   Satisfaction +  SocialSupport + Smoking +
  +   Radiation
  > 
  > psfmi::pool_D4(data=lbpmilr, nimp=10, impvar="Impnr",
  +                fm0=fm0, fm1=fm1, robust = TRUE)
  Error in `filter()`: Problem while computing `..1 = data[impvar] <= nimp`.
  ✖ Input `..1` must be a logical vector, not a logical[,1].
  Backtrace:
       ▆
    1. ├─psfmi::pool_D4(...)
    2. │ ├─dplyr::filter(data, data[impvar] <= nimp)
    3. │ └─dplyr:::filter.data.frame(data, data[impvar] <= nimp)
    4. │   └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    5. │     └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
    6. │       ├─base::withCallingHandlers(...)
    7. │       └─mask$eval_all_filter(dots, env_filter)
    8. ├─dplyr:::dplyr_internal_error(...)
    9. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   10. │   └─rlang:::signal_abort(cnd, .file)
   11. │     └─base::signalCondition(cnd)
   12. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

> checking dependencies in R code ... NOTE
  Namespace in Imports field not imported from: ‘miceadds’
    All declared Imports should be used.

1 error x | 0 warnings ✓ | 1 note x
````

Please consider this pull request that should fix the issue. 