### PR TITLE
Unname vectors supplied to tidyselect arguments

### DIFF
--- a/R/cv_MI.R
+++ b/R/cv_MI.R
@@ -38,8 +38,9 @@ cv_MI <- function(pobj, data_orig, folds, nimp_cv, BW, p.crit, miceImp, ...)
     # Stratified on outcome
     # Extract row id's in first imputed dataset
     # to apply in each imputed dataset
+    strata <- unlist(data_orig[pobj$Outcome], use.names = FALSE)
     idfold <-
-      map(vfold_cv(data_orig, v=folds, strata = unlist(data_orig[pobj$Outcome]))$splits,
+      map(vfold_cv(data_orig, v=folds, strata = strata)$splits,
           function(x) id_test <- as.integer(row.names(x[[1]]))[-x[[2]]])
 
     Pred <-

--- a/R/cv_MI_RR.R
+++ b/R/cv_MI_RR.R
@@ -25,8 +25,9 @@ cv_MI_RR <- function(pobj, data_orig, folds, nimp_mice, p.crit, BW, miceImp, ...
 {
 
   # Single fold definition
+  strata <- unlist(data_orig[pobj$Outcome], use.names = FALSE)
   idfold <- map(vfold_cv(data_orig, v=folds,
-                         strata = unlist(data_orig[pobj$Outcome]))$splits,
+                         strata = strata)$splits,
                 function(x)
                   id_test <- as.integer(row.names(x[[1]]))[-x[[2]]])
 


### PR DESCRIPTION
Named vectors normally have renaming semantics, e.g. they should do the same thing as `select(mtcars, foo = cyl)`. These names were erroneously ignored and we fixed this in vctrs 0.5.0 which we plan to send to CRAN soon. This causes your vignettes and examples to fail, which I fix here.